### PR TITLE
start on tree and treebuilder

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Extension configuration -------------------------------------------------
 autosummary_generate = True
-numpydoc_show_class_members = False 
+numpydoc_show_class_members = False
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/project_info/contributing.rst
+++ b/docs/project_info/contributing.rst
@@ -15,7 +15,7 @@ Report a bug
 ~~~~~~~~~~~~
 If you have found a bug, please report it on `our issues page <https://github.com/aryarm/happler/issues>`_ rather than emailing us directly. Others may have the same issue and this helps us get that information to them.
 
-Before you submit a bug, please search through our issues to ensure it hasn't already been reported.
+Before you submit a bug, please search through our issues to ensure it hasn't already been reported. If you encounter an issue that has already been reported, please upvote it by reacting with a thumbs-up emoji. This helps us prioritize the issue.
 
 The most helpful Github issues include
     - the version of happler you are using, although it's best to use the latest version
@@ -39,22 +39,24 @@ How to fix a bug or implement a new feature
 Please create a pull request! A PR is a collection of changes that you have made to the code that we can review and potentially integrate into happler.
 
 To create a pull request you need to do these steps:
-    1. Create a Github account.
-    2. `Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo#forking-a-repository>`_ the repository.
+    1. Create a Github account
+    2. `Fork the repository <https://docs.github.com/en/get-started/quickstart/fork-a-repo#forking-a-repository>`_
         - Click the "Fork" button in the top, right corner
-        - Or, if you had already forked the repository a while ago, `sync your fork <https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/syncing-a-fork>`_ to make sure you're working with the latest version of happler.
-    3. `Clone your fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo#cloning-your-forked-repository>`_ locally.
+        - Or, if you had already forked the repository a while ago, `sync your fork <https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/syncing-a-fork>`_ to make sure you're working with the latest version of happler
+    3. `Clone your fork locally <https://docs.github.com/en/get-started/quickstart/fork-a-repo#cloning-your-forked-repository>`_
     4. :code:`cd happler` into the new directory
-    5. Create a new branch with :code:`git checkout -b <descriptive_branch_name>`
-    6. Setup our development environment by following the instructions in "Dev Setup" below.
-    7. Make your changes to the code.
-    8. Add any additional tests to the :code:`tests/` directory and add any comments to the documentation that would help users understand how to use your new code. We use pytest for testing and sphinx/numpydoc for documentation.
-    9. Run the automated code-checking steps detailed in "Code Checks" below.
-    10. Commit your changes. Please use informative commit messages and do your best to ensure the commit history is clean and easy to interpret.
+    5. Create a new branch off of master with :code:`git checkout -b <descriptive_branch_name>`. Please follow best practices when naming your branch
+    6. Setup our development environment by following the instructions in :ref:`dev-setup-instructions` below
+    7. Make your changes to the code
+    8. Add additional tests to the :code:`tests/` directory and add comments to the documentation to explain how to use your new code. We use pytest for testing and sphinx/numpydoc for documentation
+    9. Run the automated code-checking steps detailed in :ref:`code-check-instructions` below
+    10. Commit your changes. Please use informative commit messages and do your best to ensure the commit history is clean and easy to interpret
     11. Now you can push your changes to your Github copy of happler by running :code:`git push origin <descriptive_branch_name>`
     12. Go to your Github copy of happler in your browser and create a pull request. Be sure to change the pull request target branch to :code:`main` on this original repository!
-    13. Please write an informative pull request detailing the changes you have made and why you made them. Tag any related issues by referring to them by a hashtag followed by their ID.
+    13. Please write an informative pull request detailing the changes you have made and why you made them. Tag any related issues by referring to them by a hashtag followed by their ID
 
+
+.. _dev-setup-instructions:
 
 ------------
 Dev Setup
@@ -62,21 +64,21 @@ Dev Setup
 
 Follow these steps to set up a development environment.
 
-1. Create a conda environment with ``poetry``
+1. Create a conda environment with ``python``
 
-    .. code-block:: console
+    .. code-block:: bash
 
-        conda create -n happler-dev  'conda-forge::poetry==1.1.11'
+        conda create -n happler-dev 'conda-forge::poetry==1.1.11'
 2. Activate the environment
 
-    .. code-block:: console
+    .. code-block:: bash
 
         conda activate happler-dev
 3. Install our dependencies
 
-    .. code-block:: console
+    .. code-block:: bash
 
-        poetry install -E docs test
+        poetry install -E docs -E test
 
 ---------------------
 Managing Dependencies
@@ -85,9 +87,11 @@ Run ``poetry help`` to read about the suite of commands it offers for managing d
 
 For example, to add a pypi dependency to our list and install it, just run
 
-    .. code-block:: console
+    .. code-block:: bash
 
         poetry add <dependency>
+
+.. _code-check-instructions:
 
 -----------
 Code Checks
@@ -96,20 +100,20 @@ Before creating your pull request, please do the following.
 
 1. Format the code correctly
 
-    .. code-block:: console
+    .. code-block:: bash
 
         black .
 
 2. If you made changes to the docs, check that they appear correctly.
 
-    .. code-block:: console
+    .. code-block:: bash
 
-        (cd docs && make html)
+        ( cd docs && sphinx-build -M html . _build )
         open docs/_build/html/index.html
 
 3. Run all of the tests
 
-    .. code-block:: console
+    .. code-block:: bash
 
         pytest tests/
 

--- a/happler/__main__.py
+++ b/happler/__main__.py
@@ -99,6 +99,7 @@ def run(
     ph = data.Phenotypes.load(phenotypes, samples=samples)
     hap_tree = tree.TreeBuilder(gt, ph)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # run the CLI if someone tries 'python -m happler' on the command line
     main(prog_name="happler")

--- a/happler/data/__init__.py
+++ b/happler/data/__init__.py
@@ -1,3 +1,4 @@
 from .data import Data
+from .genotypes import VariantType
 from .genotypes import Genotypes
 from .phenotypes import Phenotypes

--- a/happler/data/__init__.py
+++ b/happler/data/__init__.py
@@ -1,4 +1,3 @@
 from .data import Data
-from .genotypes import VariantType
-from .genotypes import Genotypes
+from .genotypes import VariantType, Genotypes
 from .phenotypes import Phenotypes

--- a/happler/data/genotypes.py
+++ b/happler/data/genotypes.py
@@ -7,6 +7,38 @@ from cyvcf2 import VCF, Variant
 from .data import Data
 
 
+class VariantType:
+    """
+    A class denoting the type of variant
+
+    Attributes
+    ----------
+    type : str, optional
+        The type of variant (ex: SNP, STR, etc)
+
+        Defaults to a single nucleotide polymorphism
+
+    """
+
+    def __init__(self, variant_type: str = "snp"):
+        # TODO: add support for STRs, SVs, etc
+        supported_types = ["snp"]
+        # a VariantType has a dtype of str
+        self.dtype = np.dtype("S5")
+        # store the type if it is supported
+        variant_type = variant_type.lower()
+        if variant_type in supported_types:
+            self.type = variant_type
+        else:
+            raise ValueError("{}s are not yet supported.".format(variant_type.upper()))
+
+    def __repr__(self):
+        return self.type.upper()
+
+    def __eq__(self, other):
+        return self.type == other.type
+
+
 class Genotypes(Data):
     """
     A class for processing genotypes from a file
@@ -74,7 +106,7 @@ class Genotypes(Data):
             The region from which to extract genotypes; ex: 'chr1:1234-34566' or 'chr7'
 
             For this to work, the VCF must be indexed and the seqname must match!
-            
+
             Defaults to loading all genotypes
         samples : List[str], optional
             A subset of the samples from which to extract genotypes

--- a/happler/data/genotypes.py
+++ b/happler/data/genotypes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import numpy as np
-from typing import List
 from pathlib import Path
 from cyvcf2 import VCF, Variant
 
@@ -68,7 +67,7 @@ class Genotypes(Data):
 
     @classmethod
     def load(
-        cls: Genotypes, fname: Path, region: str = None, samples: List[str] = None
+        cls: Genotypes, fname: Path, region: str = None, samples: list[str] = None
     ) -> Genotypes:
         """
         Load genotypes from a VCF file
@@ -81,7 +80,7 @@ class Genotypes(Data):
             See documentation for :py:attr:`~.Data.fname`
         region : str, optional
             See documentation for :py:meth:`~.Genotypes.read`
-        samples : List[str], optional
+        samples : list[str], optional
             See documentation for :py:meth:`~.Genotypes.read`
 
         Returns
@@ -96,7 +95,7 @@ class Genotypes(Data):
         # genotypes.to_MAC()
         return genotypes
 
-    def read(self, region: str = None, samples: List[str] = None):
+    def read(self, region: str = None, samples: list[str] = None):
         """
         Read genotypes from a VCF into a numpy matrix stored in :py:attr:`~.Genotypes.data`
 
@@ -108,7 +107,7 @@ class Genotypes(Data):
             For this to work, the VCF must be indexed and the seqname must match!
 
             Defaults to loading all genotypes
-        samples : List[str], optional
+        samples : list[str], optional
             A subset of the samples from which to extract genotypes
 
             Defaults to loading genotypes from all samples
@@ -261,7 +260,7 @@ class GenotypesPLINK(Data):
 
     @classmethod
     def load(
-        cls: Genotypes, fname: Path, region: str = None, samples: List[str] = None
+        cls: Genotypes, fname: Path, region: str = None, samples: list[str] = None
     ) -> Genotypes:
         """
         Load genotypes from a VCF file
@@ -274,7 +273,7 @@ class GenotypesPLINK(Data):
             See documentation for :py:attr:`~.Data.fname`
         region : str, optional
             See documentation for :py:meth:`~.Genotypes.read`
-        samples : List[str], optional
+        samples : list[str], optional
             See documentation for :py:meth:`~.Genotypes.read`
 
         Returns
@@ -289,7 +288,7 @@ class GenotypesPLINK(Data):
         # genotypes.to_MAC()
         return genotypes
 
-    def read(self, region: str = None, samples: List[str] = None):
+    def read(self, region: str = None, samples: list[str] = None):
         """
         Read genotypes from a VCF into a numpy matrix stored in :py:attr:`~.Genotypes.data`
 
@@ -301,7 +300,7 @@ class GenotypesPLINK(Data):
             For this to work, the VCF must be indexed and the seqname must match!
 
             Defaults to loading all genotypes
-        samples : List[str], optional
+        samples : list[str], optional
             A subset of the samples from which to extract genotypes
 
             Defaults to loading genotypes from all samples

--- a/happler/data/phenotypes.py
+++ b/happler/data/phenotypes.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import numpy as np
 from csv import reader
-from typing import List
 from pathlib import Path
 
 from .data import Data
@@ -28,7 +27,7 @@ class Phenotypes(Data):
         self.samples = tuple()
 
     @classmethod
-    def load(cls: Phenotypes, fname: Path, samples: List[str] = None) -> Phenotypes:
+    def load(cls: Phenotypes, fname: Path, samples: list[str] = None) -> Phenotypes:
         """
         Load phenotypes from a TSV file
 
@@ -38,7 +37,7 @@ class Phenotypes(Data):
         ----------
         fname
             See documentation for :py:attr:`~.Data.fname`
-        samples : List[str], optional
+        samples : list[str], optional
             See documentation for :py:meth:`~.Data.Phenotypes.read`
 
         Returns
@@ -51,13 +50,13 @@ class Phenotypes(Data):
         phenotypes.standardize()
         return phenotypes
 
-    def read(self, samples: List[str] = None):
+    def read(self, samples: list[str] = None):
         """
         Read phenotypes from a TSV file into a numpy matrix stored in :py:attr:`~.Penotypes.data`
 
         Parameters
         ----------
-        samples : List[str], optional
+        samples : list[str], optional
             A subset of the samples from which to extract phenotypes
 
             Defaults to loading phenotypes from all samples

--- a/happler/tree/__init__.py
+++ b/happler/tree/__init__.py
@@ -1,2 +1,3 @@
+from .tree import Node
 from .tree import Tree
 from .treebuilder import TreeBuilder

--- a/happler/tree/__init__.py
+++ b/happler/tree/__init__.py
@@ -1,3 +1,2 @@
-from .tree import Node
-from .tree import Tree
 from .treebuilder import TreeBuilder
+from .tree import Node, Haplotype, Tree

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -1,9 +1,9 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from collections import defaultdict
+
 import numpy as np
 import networkx as nx
-
-from dataclasses import dataclass
-from __future__ import annotations
-from collections import defaultdict
 
 from ..data import VariantType
 

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -1,9 +1,16 @@
 import numpy as np
 import networkx as nx
 
+from dataclasses import dataclass
+from __future__ import annotations
+from collections import defaultdict
+
 from ..data import VariantType
 
 
+# We declare this class to be a dataclass to automatically define __init__ and a few
+# other methods. We use frozen=True to make it immutable.
+@dataclass(frozen=True)
 class Node:
     """
     A node within the tree
@@ -16,45 +23,30 @@ class Node:
         The index of the variant within the genotype data
     pos : int
         The chromosomal position of the variant
-    type : VariantType
-        The type of variant
-    _tree_idx : int
-        The index of the variant within the tree
     """
 
-    __slots__ = "idx", "id", "pos", "type"
-
-    def __init__(
-        self,
-        idx: int,
-        ID: str,
-        pos: int,
-        variant_type: VariantType = VariantType("snp"),
-    ):
-        self.idx = idx
-        self.id = ID
-        self.pos = pos
-        self.type = variant_type
-        self._tree_idx = None
+    idx: int
+    id: int
+    pos: int
 
     @classmethod
-    def from_np(cls, idx: int, np_mixed_arr_var: np.void):
+    def from_np(cls, np_mixed_arr_var: np.void, idx: int) -> Node:
         """
         Convert a numpy mixed array variant record into a Node
 
         Parameters
         ----------
-        idx : int
-            See :py:attr:`~.Node.idx`
         np_mixed_arr_var : np.void
             A numpy mixed array variant record with entries 'id' and 'pos'
+        idx : int
+            See :py:attr:`~.Node.idx`
 
         Returns
         -------
         Node
             The converted Node
         """
-        return cls(idx=idx, ID=np_mixed_arr_var["id"], pos=np_mixed_arr_var["pos"])
+        return cls(idx=idx, id=np_mixed_arr_var["id"], pos=np_mixed_arr_var["pos"])
 
     @property
     def ID(self):
@@ -64,14 +56,72 @@ class Node:
     def POS(self):
         return self.pos
 
-    def __repr__(self):
-        return self.id
 
-    def __hash__(self):
-        return self._tree_idx
+# We declare this class to be a dataclass to automatically define __init__ and a few
+# other methods. We use frozen=True to make it immutable.
+@dataclass(frozen=True)
+class Haplotype:
+    """
+    A haplotype within the tree
 
-    def __eq__(self, other):
-        return self.idx == other.idx
+    Attributes
+    ----------
+    nodes : tuple[tuple[Node, int]]
+        An ordered collection of pairs, where each pair is a node and its allele
+    """
+
+    # TODO: consider using a named tuple? ugh maybe we want both a Node class and a
+    # Variant class?
+    nodes: tuple[tuple[Node, int]]
+
+    @classmethod
+    def from_node(cls, node: Node, allele: int) -> Haplotype:
+        """
+        Create a new haplotype with a single node entry
+
+        Parameters
+        ----------
+        node : Node
+            The initializing node for this haplotype
+        allele : int
+            The allele associated with node
+
+        Returns
+        -------
+        Haplotype
+            The newly created haplotype object containing node and allele
+        """
+        return cls(((Node, allele),))
+
+    def append(self, node: Node, allele: int) -> Haplotype:
+        """
+        Append a new node to this haplotype
+
+        Parameters
+        ----------
+        node : Node
+            The node to add to this haplotype
+        allele : int
+            The allele associated with this node
+
+        Returns
+        -------
+        Haplotype
+            A new haplotype object extended by the node and its allele
+        """
+        return Haplotype(self.nodes + ((Node, allele),))
+
+    @property
+    def node_indices(self) -> tuple[int]:
+        """
+        Get the indices of the nodes in this haplotype
+
+        Returns
+        -------
+        tuple
+            The indices of the nodes
+        """
+        return tuple(node[0].idx for node in self.nodes)
 
 
 class Tree:
@@ -85,7 +135,66 @@ class Tree:
     ----------
     graph: nx.DiGraph
         The underlying directed acyclic graph representing the tree
+    variant_locs: dict
+        The indices of each variant within the tree's list of nodes
     """
 
-    def __init__(self):
+    def __init__(self, root: None):
         self.graph = nx.DiGraph()
+        self.variant_locs = defaultdict(set)
+        self._add_root_node(root)
+
+    @property
+    def num_nodes(self):
+        return self.graph.number_of_nodes()
+
+    def _add_root_node(self, root: Node):
+        """
+        Initialize the tree with a root node
+
+        Parameters
+        ----------
+        root : Node
+            See :py:attr:`_.Tree.root`
+        """
+        # TODO: consider reducing code duplication between this method and add_node()
+        self.variant_locs[root].add(self.num_nodes)
+        self.graph.add_node(self.num_nodes, idx=root.idx, label=root.id)
+
+    def add_node(self, node: Node, parent_idx: int, allele: int) -> int:
+        """
+        Add node to the tree
+
+        Parameters
+        ----------
+        node : Node
+            The node to add to the tree
+        parent_idx : int
+            The index of the node under which to place the new node
+        allele : int
+            The allele for the edge from parent to node
+
+        Returns
+        -------
+        int
+            The index of the new node within the tree
+        """
+        new_node_idx = self.num_nodes
+        self.graph.add_node(new_node_idx, idx=node.idx, label=node.id)
+        self.variant_locs[node].add(new_node_idx)
+        self.graph.add_edge(parent_idx, new_node_idx, label=allele)
+        return new_node_idx
+
+    def ascii(self) -> str:
+        """
+        Convert the tree to its ascii representation
+        This is useful for quickly viewing the tree on the command line
+
+        Returns
+        -------
+        str
+            A string representing the tree
+
+            Nodes are labeled by their variant ID and edges are labeled by their allele
+        """
+        pass

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -1,4 +1,77 @@
+import numpy as np
 import networkx as nx
+
+from ..data import VariantType
+
+
+class Node:
+    """
+    A node within the tree
+
+    Attributes
+    ----------
+    id : str
+        The variant's unique ID
+    idx : int
+        The index of the variant within the genotype data
+    pos : int
+        The chromosomal position of the variant
+    type : VariantType
+        The type of variant
+    _tree_idx : int
+        The index of the variant within the tree
+    """
+
+    __slots__ = "idx", "id", "pos", "type"
+
+    def __init__(
+        self,
+        idx: int,
+        ID: str,
+        pos: int,
+        variant_type: VariantType = VariantType("snp"),
+    ):
+        self.idx = idx
+        self.id = ID
+        self.pos = pos
+        self.type = variant_type
+        self._tree_idx = None
+
+    @classmethod
+    def from_np(cls, idx: int, np_mixed_arr_var: np.void):
+        """
+        Convert a numpy mixed array variant record into a Node
+
+        Parameters
+        ----------
+        idx : int
+            See :py:attr:`~.Node.idx`
+        np_mixed_arr_var : np.void
+            A numpy mixed array variant record with entries 'id' and 'pos'
+
+        Returns
+        -------
+        Node
+            The converted Node
+        """
+        return cls(idx=idx, ID=np_mixed_arr_var["id"], pos=np_mixed_arr_var["pos"])
+
+    @property
+    def ID(self):
+        return self.id
+
+    @property
+    def POS(self):
+        return self.pos
+
+    def __repr__(self):
+        return self.id
+
+    def __hash__(self):
+        return self._tree_idx
+
+    def __eq__(self, other):
+        return self.idx == other.idx
 
 
 class Tree:

--- a/happler/tree/treebuilder.py
+++ b/happler/tree/treebuilder.py
@@ -1,4 +1,4 @@
-from .tree import Tree
+from .tree import Node, Haplotype, Tree
 from ..data import Genotypes, Phenotypes
 
 
@@ -19,7 +19,62 @@ class TreeBuilder:
     def __init__(self, genotypes: Genotypes, phenotypes: Phenotypes):
         self.gens = genotypes
         self.phens = phenotypes
-        self.tree = Tree()
+        self.tree = None
 
     def __repr__(self):
         return self.gens, self.phens
+
+    def run(self, root: int):
+        """
+        Run the tree builder and create a tree rooted at the provided variant
+
+        Parameters
+        ----------
+        root : int
+            The index of the variant to use at the root of tree. This should be an
+            index into :py:attr:`~.TreeBuilder.gens`
+        """
+        # step one: initialize the tree
+        root_node = Node.from_np(self.gens[root], idx=root)
+        self.tree = Tree(root_node)
+        # step two: create the tree
+        self._create_tree(root_node)
+
+    def _create_tree(
+        self, parent: Node, parent_hap: Haplotype = None, parent_idx: int = 0
+    ):
+        """
+        Recursive helper to the run() function
+
+        Adds a subtree under the node with index parent_idx in the tree
+
+        Parameters
+        ----------
+        parent : Node
+            An existing node in the tree under which we should consider creating a subtree
+        parent_hap : Haplotype
+            The haplotype containing all variants up to (but NOT including) the parent
+        parent_idx : int
+            The index of the parent node in the tree
+        """
+        # we consider two possible alleles
+        alleles = (0, 1)
+        for allele in alleles:
+            # find the best variant, add it to the tree, and then create a new subtree
+            # under it
+            best_variant = self._find_split(parent_idx, allele)
+            new_node_idx = self.tree.add_node(best_variant, parent_idx, allele)
+            if parent_hap is None:
+                parent_hap = Haplotype()
+            parent_hap.append(parent, allele)
+            self._create_tree(best_variant, parent_hap, new_node_idx)
+
+    def _find_split(self, parent: Haplotype, parent_idx: int, allele: int) -> Node:
+        """
+        Find the variant that best fits under the parent_idx node with the allele edge
+
+        Parameters
+        ----------
+        TODO
+        """
+        pass

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from pathlib import Path
 
-from happler.data import Genotypes, Phenotypes
+from happler.data import VariantType, Genotypes, Phenotypes
 
 
 DATADIR = Path(__file__).parent.joinpath("data")
@@ -132,3 +132,12 @@ def test_load_phenotypes_subset():
     phens.read(samples=samples)
     np.testing.assert_allclose(phens.data, expected)
     assert phens.samples == tuple(samples)
+
+
+def test_variant_type():
+    assert VariantType("snp") == VariantType("SNP")
+
+    assert str(VariantType("snp")) == "SNP"
+
+    with pytest.raises(ValueError):
+        VariantType("indel")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+
 from pathlib import Path
 
 from happler.data import VariantType, Genotypes, Phenotypes

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -2,15 +2,33 @@ import pytest
 import numpy as np
 from pathlib import Path
 
-from happler.data import Genotypes, Phenotypes
-from happler.tree import Tree, TreeBuilder
+from happler.data import VariantType, Genotypes, Phenotypes
+from happler.tree import Node, Tree, TreeBuilder
 
 
 DATADIR = Path(__file__).parent.joinpath("data")
 
 
+def test_node():
+    node = Node(idx=0, ID="SNP0", pos=1)
+    assert node.type == VariantType("snp")
+    assert node.id == "SNP0"
+
+    np_node = np.array(
+        [(node.id, "1", node.pos, "0.25")],
+        dtype=[
+            ("id", "U50"),
+            ("chrom", "U10"),
+            ("pos", np.uint),
+            ("aaf", np.float64),
+        ],
+    )
+    assert node == Node.from_np(node.idx, np_node[0])
+
+
 def test_tree():
-    tree = Tree()
+    node = Node(idx=0, ID="SNP0", pos=1)
+    tree = Tree(root_node=node)
 
 
 def test_tree_builder():

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+
 from pathlib import Path
 
 from happler.data import VariantType, Genotypes, Phenotypes
@@ -10,8 +11,7 @@ DATADIR = Path(__file__).parent.joinpath("data")
 
 
 def test_node():
-    node = Node(idx=0, ID="SNP0", pos=1)
-    assert node.type == VariantType("snp")
+    node = Node(idx=0, id="SNP0", pos=1)
     assert node.id == "SNP0"
 
     np_node = np.array(
@@ -23,15 +23,23 @@ def test_node():
             ("aaf", np.float64),
         ],
     )
-    assert node == Node.from_np(node.idx, np_node[0])
+    assert node == Node.from_np(np_node[0], node.idx)
 
 
 def test_tree():
-    node = Node(idx=0, ID="SNP0", pos=1)
-    tree = Tree(root_node=node)
+    node = Node(idx=0, id="SNP0", pos=1)
+    tree = Tree(root=node)
+
+    assert tree.num_nodes == 1
+
+    tree.add_node(Node(idx=0, id="SNP1", pos=2), 0, 0)
+
+    assert tree.num_nodes == 2
 
 
 def test_tree_builder():
     gens = Genotypes.load(DATADIR.joinpath("simple.vcf.gz"))
     phens = Phenotypes.load(DATADIR.joinpath("simple.tsv"))
     tree_builder = TreeBuilder(gens, phens)
+    # root_node =
+    # tree_builder.run(root_node)


### PR DESCRIPTION
## new classes
classes created in [`happler/data/genotypes.py`](https://github.com/aryarm/happler/pull/13/files#diff-b3fe17c8fedf39c2a361330818036b6be887fe1567d6d2b54634b0f7259fd32a):
- VariantType - with plans to integrate this into the numpy mixed array type for genotypes

in [`happler/tree/tree.py`](https://github.com/aryarm/happler/pull/13/files#diff-bbf1c582da29f3b8b6913a2ddb1007b72da5dd12d1e79c7f8578cdc46c6bbff1):
- Node - for storing references to genotype entries and passing those references around when building the tree
- Haplotype - for representing sets of variants at each node in the tree

## methods in existing classes
in `Tree`:
- `_add_root_node`
- `add_node`
- `ascii` (I anticipate needing this eventually - see #12)

in `TreeBuilder`:
- `run`
- `_create_tree` - the recursive helper to `run`
- `_find_split`
