### PR TITLE
create more example tests and add tree termination tests

### DIFF
--- a/docs/api/happler.rst
+++ b/docs/api/happler.rst
@@ -45,7 +45,7 @@ happler.tree.tree module
    :show-inheritance:
 
 happler.tree.tree_builder module
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: happler.tree.tree_builder
    :members:
@@ -53,7 +53,7 @@ happler.tree.tree_builder module
    :show-inheritance:
 
 happler.tree.variant module
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: happler.tree.variant
    :members:

--- a/docs/executing/outputs.rst
+++ b/docs/executing/outputs.rst
@@ -1,0 +1,92 @@
+.. _executing-outputs:
+
+
+Outputs
+=========
+
+Haplotype file format
+---------------------
+Discovered haplotypes will be written in a special ``.haps`` file format.
+
+This is a tab-separated file composed of different types of lines. The first field of each line is a single, uppercase character denoting the type of line.
+
+.. list-table::
+   :widths: 25 25
+   :header-rows: 1
+
+   * - Type
+     - Description
+   * - #
+     - Comment
+   * - M
+     - Metadata
+   * - H
+     - Haplotype
+   * - V
+     - Variant
+
+``#`` Comment line
+~~~~~~~~~~~~~~~~~~
+Comment lines begin with ``#`` and are ignored.
+
+``M`` Metadata
+~~~~~~~~~~~~~~
+Describes attributes of the file, itself, including the version of the format spec.
+
+``H`` Haplotype
+~~~~~~~~~~~~~~~
+Haplotypes contain the following attributes:
+
+.. list-table::
+   :widths: 25 25 25 50
+   :header-rows: 1
+
+   * - Column
+     - Field
+     - Type
+     - Description
+   * - 1
+     - Haplotype ID
+     - int
+     - Identifies a haplotype within a tree; unique across other haplotypes in the tree
+   * - 2
+     - Tree ID
+     - int
+     - A unique identifier for the tree that this haplotype belongs to
+   * - 3
+     - Effect size
+     - float
+     - The effect size of the association between this haplotype and the trait
+   * - 4
+     - p-value
+     - float
+     - The p-value of the association between this haplotype and the trait
+   * - 5
+     - PIP
+     - float
+     - The posterior inclusion probability for the causality of this haplotype
+
+``V`` Variant
+~~~~~~~~~~~~~
+Variant lines must follow the haplotype to which they belong. They contain the following attributes:
+
+.. list-table::
+   :widths: 25 25 25 50
+   :header-rows: 1
+
+   * - Column
+     - Field
+     - Type
+     - Description
+   * - 1
+     - Variant ID
+     - string
+     - The unique ID for this variant, as defined in the genotypes file
+   * - 2
+     - Allele
+     - bool
+     - The allele of this variant within the haplotype
+   * - 3
+     - Score
+     - float
+     - The importance of including this variant within the haplotype

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,8 @@ happler
 =======
 
 .. toctree::
-   :caption: Execution
-   :name: executing
+   :caption: Inputs
+   :name: inputs
    :hidden:
    :maxdepth: 1
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,14 @@ happler
    executing/inputs.rst
 
 .. toctree::
+   :caption: Outputs
+   :name: outputs
+   :hidden:
+   :maxdepth: 1
+
+   executing/outputs.rst
+
+.. toctree::
    :caption: API
    :name: api
    :hidden:

--- a/happler/tree/__init__.py
+++ b/happler/tree/__init__.py
@@ -1,4 +1,4 @@
-from .tree import Tree
+from .tree import Tree, NodeResults
 from .tree_builder import TreeBuilder
 from .variant import VariantType, Variant
 from .haplotypes import Haplotype, Haplotypes

--- a/happler/tree/assoc_test.py
+++ b/happler/tree/assoc_test.py
@@ -18,10 +18,10 @@ class AssocResults:
     Attributes
     ----------
     data : npt.NDArray[np.float64]
-        A numpy mixed array with fields: beta and pval
+        A numpy mixed array with fields: beta, pval, stderr
     """
 
-    data: npt.NDArray[np.float64, np.float64]
+    data: npt.NDArray[np.float64, np.float64, np.float64]
 
 
 class AssocTest(ABC):
@@ -82,7 +82,7 @@ class AssocTestSimple(AssocTest):
         npt.NDArray[np.float64]
             The p-values from testing each haplotype, with shape p x 1
         """
-        extract_vals = lambda linreg: (linreg.slope, linreg.pvalue)
+        extract_vals = lambda linreg: (linreg.slope, linreg.pvalue, linreg.stderr)
         # use ordinary least squares for a simple regression
         # return an array of p-values
         return AssocResults(
@@ -94,6 +94,7 @@ class AssocTestSimple(AssocTest):
                 dtype=[
                     ("beta", np.float64),
                     ("pval", np.float64),
+                    ("stderr", np.float64),
                 ],
             )
         )

--- a/happler/tree/haplotypes.py
+++ b/happler/tree/haplotypes.py
@@ -127,6 +127,7 @@ class Haplotypes:
     ----------
     data : list[dict]
         A list of dict describing the composition of a series of haplotypes
+
         Each haplotype dictionary is composed of these items:
             1) id (int): A haplotype ID
             2) tree (int): A tree ID
@@ -134,6 +135,7 @@ class Haplotypes:
             4) pval (float): The p-value of the haplotype-phenotype association
             5) pip (float): A PIP from running SuSiE or some other tool
             6) variants (list[dict]): A list of dictionaries, one for each variant:
+
         Each variants dictionary is composed of these items:
             1) id (int): A variant ID
             2) allele (bool): The allele for this variant

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from dataclasses import dataclass
 from collections.abc import Iterable
 from collections import defaultdict, deque
 
@@ -7,6 +8,37 @@ import numpy as np
 import networkx as nx
 
 from .variant import Variant
+
+
+# We declare this class to be a dataclass to automatically define __init__ and a few
+# other methods. We use frozen=True to make it immutable.
+@dataclass(frozen=True)
+class NodeResults:
+    """
+    The results of testing SNPs at a node in the tree
+
+    Attributes
+    ----------
+    beta : float
+        The best effect size among all of the SNPs tried
+    pval : float
+        The best p-value among all of the SNPs tried
+    """
+
+    beta: float
+    pval: float
+
+    def __getitem__(self, item):
+        """
+        Define a getter so that we can access elemeents like this:
+
+        ``obj['field_name']``
+
+        in addition to this:
+
+        ``obj.field_name``
+        """
+        return getattr(self, item)
 
 
 class Tree:
@@ -49,7 +81,7 @@ class Tree:
         )
 
     def add_node(
-        self, node: Variant, parent_idx: int, allele: int, results: np.void = None
+        self, node: Variant, parent_idx: int, allele: int, results: NodeResults = None
     ) -> int:
         """
         Add node to the tree

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .tree import Tree
+from .tree import Tree, NodeResults
 from ..data import Genotypes, Phenotypes
 from .variant import Variant
 from .haplotypes import Haplotype
@@ -87,14 +87,16 @@ class TreeBuilder:
                 new_parent_hap = parent_hap.append(parent, allele, variant_gts)
             # find the best variant, add it to the tree, and then create a new subtree
             # under it
-            best_variant, results = self._find_split(new_parent_hap, parent_idx, allele)
+            best_variant, results = self._find_split(
+                new_parent_hap, parent_idx, allele, results
+            )
             if best_variant is None:
                 continue
             new_node_idx = self.tree.add_node(best_variant, parent_idx, allele, results)
             self._create_tree(best_variant, new_parent_hap, new_node_idx)
 
     def _find_split(
-        self, parent: Haplotype, parent_idx: int, allele: int
+        self, parent: Haplotype, parent_idx: int, allele: int, parent_res: NodeResults
     ) -> tuple[Variant, np.void]:
         """
         Find the variant that best fits under the parent_idx node with the allele edge
@@ -107,6 +109,8 @@ class TreeBuilder:
             The index of the parent node in the tree
         allele : int
             The allele of the parent node in the tree
+        parent_res : NodeResults
+            The results of the tests performed on the parent node
 
         Returns
         -------
@@ -126,8 +130,9 @@ class TreeBuilder:
         # step 3: find the index of the best variant within the haplotype matrix
         best_p_idx = p_values.argmin()
         best = results.data[best_p_idx]
+        node_res = NodeResults(beta=best["beta"], pval=best["pval"])
         # step 4: check whether we should terminate the branch
-        if self.check_terminate_branch(best["pval"], len(p_values)):
+        if self.check_terminate_branch(parent_res, node_res):
             return None, best
         # step 5: find the index of the best variant within the genotype matrix
         # we need to account for indices that we removed when running transform()
@@ -139,24 +144,28 @@ class TreeBuilder:
                 break
             best_p_idx += 1
         # step 6: return the Variant with the best p-value
-        return Variant.from_np(self.gens.variants[best_p_idx], best_p_idx), best
+        best_variant = Variant.from_np(self.gens.variants[best_p_idx], best_p_idx)
+        return best_variant, node_res
 
-    def check_terminate_branch(self, pval: float, num_tests: int) -> bool:
+    def check_terminate_branch(
+        self, parent_res: NodeResults, node_res: NodeResults
+    ) -> bool:
         """
         Check whether this branch should be terminated.
 
         Parameters
         ----------
-        pval : float
-            The best p-value amongst all tests performed on this branch.
-        num_tests : int
-            The number of tests performed on this branch.
+        parent_res : NodeResults
+            The results of the tests performed on the parent node
+        node_res : NodeResults
+            The results of the tests performed on the current node
 
         Returns
         -------
         bool
             True if the branch should be terminated, False otherwise
         """
+        pass  # TODO
         # correct for multiple hypothesis testing
         # For now, we use the Bonferroni correction
         # TODO: perform a likelihood ratio test?

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -59,7 +59,7 @@ class TreeBuilder:
         return self.tree
 
     def _create_tree(
-        self, parent: Variant, parent_hap: Haplotype = None, parent_idx: int = 0
+        self, parent: Variant, parent_hap: Haplotype = None, parent_idx: int = 0, parent_res: NodeResults = None
     ):
         """
         Recursive helper to the run() function
@@ -88,12 +88,12 @@ class TreeBuilder:
             # find the best variant, add it to the tree, and then create a new subtree
             # under it
             best_variant, results = self._find_split(
-                new_parent_hap, parent_idx, allele, results
+                new_parent_hap, parent_idx, allele, parent_res
             )
             if best_variant is None:
                 continue
             new_node_idx = self.tree.add_node(best_variant, parent_idx, allele, results)
-            self._create_tree(best_variant, new_parent_hap, new_node_idx)
+            self._create_tree(best_variant, new_parent_hap, new_node_idx, results)
 
     def _find_split(
         self, parent: Haplotype, parent_idx: int, allele: int, parent_res: NodeResults
@@ -165,7 +165,16 @@ class TreeBuilder:
         bool
             True if the branch should be terminated, False otherwise
         """
-        pass  # TODO
+        if parent_res is None:
+            # TODO: think about how to handle this case
+            # this will happen when the parent node is the root node
+            # we can either redo the association test to obtain an effect size and p-value
+            # or we can choose not to terminate
+            # right now, we're just choosing not to terminate
+            return True
+        else:
+            # perform a two tailed, two-sample t-test using the difference of the effect sizes
+            pass
         # correct for multiple hypothesis testing
         # For now, we use the Bonferroni correction
         # TODO: perform a likelihood ratio test?

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -150,7 +150,6 @@ def test_two_snps_independent_perfect():
     Y = 0.5 * X1 + 0.5 * X2
     """
     split_list_in_half = lambda pair: [pair[:2], pair[2:]]
-    # 4 samples
     gens = _create_fake_gens(
         np.array(
             list(map(split_list_in_half, product([0, 1], repeat=4))), dtype=np.bool_
@@ -178,7 +177,6 @@ def test_two_snps_one_branch_perfect():
             return X2
     """
     split_list_in_half = lambda pair: [pair[:2], pair[2:]]
-    # 4 samples
     gens = _create_fake_gens(
         np.array(
             list(map(split_list_in_half, product([0, 1], repeat=4))), dtype=np.bool_
@@ -200,7 +198,35 @@ def test_two_snps_one_branch_perfect():
     assert haps[0][2]["allele"] == 1
 
 
-def test_three_snps_independent_branches_perfect():
+def test_four_snps_two_independent_trees_perfect():
+    """
+    Two independent causal SNPs each sharing a haplotype with another, different SNP
+    via perfect phenotype associations
+    Y = 0.5 * ( X1 && X3 ) + 0.5 * ( X2 && X4 )
+    This should yield two haplotypes from different trees, where X3 occurs in the first
+    and X4 occurs in the second
+    """
+    # a function for splitting a list into a list of pairs
+    split_list = lambda pair: [pair[i : i + 2] for i in range(0, len(pair), 2)]
+    gens = _create_fake_gens(
+        np.array(list(map(split_list, product([0, 1], repeat=8))), dtype=np.bool_)
+    )
+    gts = gens.data
+    phens = _create_fake_phens(
+        0.5 * (gts[:, 0] & gts[:, 2]).sum(axis=1)
+        + 0.5 * (gts[:, 1] & gts[:, 3]).sum(axis=1)
+    )
+
+    # TODO: we need to handle this case, somehow
+    # # run the treebuilder and extract the haplotypes
+    # builder = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2))
+    # builder.run(root=0)
+    # tree = builder.tree
+    # haps = tree.haplotypes()
+    assert False
+
+
+def test_three_snps_two_independent_trees_perfect():
     """
     Two independent causal SNPs each sharing a haplotype with the third SNP via
     perfect phenotype associations
@@ -209,7 +235,6 @@ def test_three_snps_independent_branches_perfect():
     X1 occurs only in one and X2 occurs only in the other
     """
     split_list = lambda pair: [pair[:2], pair[2:4], pair[4:]]
-    # 4 samples
     gens = _create_fake_gens(
         np.array(list(map(split_list, product([0, 1], repeat=6))), dtype=np.bool_)
     )
@@ -241,7 +266,6 @@ def test_two_snps_two_branches_perfect():
 
     """
     split_list_in_half = lambda pair: [pair[:2], pair[2:]]
-    # 4 samples
     gens = _create_fake_gens(
         np.array(
             list(map(split_list_in_half, product([0, 1], repeat=4))), dtype=np.bool_

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -198,6 +198,37 @@ def test_two_snps_one_branch_perfect():
     assert haps[0][2]["allele"] == 1
 
 
+def test_three_snps_one_branch_one_snp_not_causal():
+    """
+    Twp causal SNPs with perfect phenotype association and one SNP that isn't causal
+    Y = 0.5 * ( X1 && X2 )
+    This should yield a single haplotype with both SNPs having the same allele.
+    The psuedocode looks like:
+        if X1:
+            return X2
+    """
+    split_list_in_half = lambda pair: [pair[:2], pair[2:], [1, 1]]
+    gens = _create_fake_gens(
+        np.array(
+            list(map(split_list_in_half, product([0, 1], repeat=4))), dtype=np.bool_
+        )
+    )
+    gts = gens.data
+    phens = _create_fake_phens(0.5 * (gts[:, 0] & gts[:, 1]).sum(axis=1))
+
+    # run the treebuilder and extract the haplotypes
+    tree = TreeBuilder(gens, phens).run(root=0)
+    haps = tree.haplotypes()
+
+    # check: did the output turn out how we expected?
+    # one haplotype: with one SNP
+    assert len(haps) == 1
+    assert len(haps[0]) == 2
+    assert haps[0][1]["variant"].id == "snp0"
+    assert haps[0][2]["variant"].id == "snp1"
+    assert haps[0][2]["allele"] == 1
+
+
 def test_four_snps_two_independent_trees_perfect():
     """
     Two independent causal SNPs each sharing a haplotype with another, different SNP
@@ -208,6 +239,67 @@ def test_four_snps_two_independent_trees_perfect():
     """
     # a function for splitting a list into a list of pairs
     split_list = lambda pair: [pair[i : i + 2] for i in range(0, len(pair), 2)]
+    gens = _create_fake_gens(
+        np.array(list(map(split_list, product([0, 1], repeat=8))), dtype=np.bool_)
+    )
+    gts = gens.data
+    phens = _create_fake_phens(
+        0.5 * (gts[:, 0] & gts[:, 2]).sum(axis=1)
+        + 0.5 * (gts[:, 1] & gts[:, 3]).sum(axis=1)
+    )
+
+    # TODO: we need to handle this case, somehow
+    # # run the treebuilder and extract the haplotypes
+    # builder = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2))
+    # builder.run(root=0)
+    # tree = builder.tree
+    # haps = tree.haplotypes()
+    assert False
+
+
+def test_four_snps_two_independent_trees_perfect_one_snp_not_causal():
+    """
+    Two independent causal SNPs each sharing a haplotype with another, different SNP
+    via perfect phenotype associations
+    Y = 0.5 * ( X1 && X3 ) + 0.5 * ( X2 && X4 )
+    This should yield two haplotypes from different trees, where X3 occurs in the first
+    and X4 occurs in the second
+    """
+    # a function for splitting a list into a list of pairs
+    split_list = lambda pair: [pair[i : i + 2] for i in range(0, len(pair), 2)] + [
+        [1, 1]
+    ]
+    gens = _create_fake_gens(
+        np.array(list(map(split_list, product([0, 1], repeat=8))), dtype=np.bool_)
+    )
+    gts = gens.data
+    phens = _create_fake_phens(
+        0.5 * (gts[:, 0] & gts[:, 2]).sum(axis=1)
+        + 0.5 * (gts[:, 1] & gts[:, 3]).sum(axis=1)
+    )
+
+    # TODO: we need to handle this case, somehow
+    # # run the treebuilder and extract the haplotypes
+    # builder = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2))
+    # builder.run(root=0)
+    # tree = builder.tree
+    # haps = tree.haplotypes()
+    assert False
+
+
+def test_four_snps_two_independent_trees_perfect_two_snps_not_causal():
+    """
+    Two independent causal SNPs each sharing a haplotype with another, different SNP
+    via perfect phenotype associations plus an extra non-causal SNP (so five SNPs total)
+    Y = 0.5 * ( X1 && X3 ) + 0.5 * ( X2 && X4 )
+    This should yield two haplotypes from different trees, where X3 occurs in the first
+    and X4 occurs in the second
+    """
+    # a function for splitting a list into a list of pairs
+    split_list = lambda pair: [pair[i : i + 2] for i in range(0, len(pair), 2)] + [
+        [1, 1],
+        [0, 0],
+    ]
     gens = _create_fake_gens(
         np.array(list(map(split_list, product([0, 1], repeat=8))), dtype=np.bool_)
     )
@@ -253,6 +345,33 @@ def test_three_snps_two_independent_trees_perfect():
     assert False
 
 
+def test_three_snps_two_independent_trees_perfect_one_snp_not_causal():
+    """
+    Two independent causal SNPs each sharing a haplotype with the third SNP via
+    perfect phenotype associations plus an extra non-causal SNP (so 4 SNPs total)
+    Y = 0.5 * ( X1 && X3 ) + 0.5 * ( X2 && X3 )
+    This should yield two haplotypes from different trees, where X3 occurs in both but
+    X1 occurs only in one and X2 occurs only in the other
+    """
+    split_list = lambda pair: [pair[:2], pair[2:4], pair[4:]] + [[1, 1]]
+    gens = _create_fake_gens(
+        np.array(list(map(split_list, product([0, 1], repeat=6))), dtype=np.bool_)
+    )
+    gts = gens.data
+    phens = _create_fake_phens(
+        0.5 * (gts[:, 0] & gts[:, 2]).sum(axis=1)
+        + 0.5 * (gts[:, 1] & gts[:, 2]).sum(axis=1)
+    )
+
+    # TODO: we need to handle this case, somehow
+    # # run the treebuilder and extract the haplotypes
+    # builder = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2))
+    # builder.run(root=0)
+    # tree = builder.tree
+    # haps = tree.haplotypes()
+    assert False
+
+
 def test_two_snps_two_branches_perfect():
     """
     Two causal SNPs on a single haplotype with perfect phenotype associations
@@ -263,9 +382,43 @@ def test_two_snps_two_branches_perfect():
             return 1
         else:
             return X2
-
     """
     split_list_in_half = lambda pair: [pair[:2], pair[2:]]
+    gens = _create_fake_gens(
+        np.array(
+            list(map(split_list_in_half, product([0, 1], repeat=4))), dtype=np.bool_
+        )
+    )
+    gts = gens.data
+    phens = _create_fake_phens(0.5 * (gts[:, 0] | gts[:, 1]).sum(axis=1))
+
+    # run the treebuilder and extract the haplotypes
+    tree = TreeBuilder(gens, phens).run(root=0)
+    haps = tree.haplotypes()
+
+    # check: did the output turn out how we expected?
+    # two haplotypes, each with both SNPs
+    assert len(haps) == 2
+    assert len(haps[0]) == 2
+    for i in range(2):
+        assert haps[i][1]["variant"].id == "snp0"
+        assert haps[i][2]["variant"].id == "snp1"
+        assert haps[i][2]["allele"] == 1
+
+
+def test_two_snps_two_branches_perfect_one_snp_not_causal():
+    """
+    Two causal SNPs on a single haplotype with perfect phenotype associations
+    plus an extra non-causal SNP
+    Y = 0.5 * ( X1 || X2 )
+    This should yield two different haplotypes for each of the alleles.
+    The pseudocode looks like:
+        if X1:
+            return 1
+        else:
+            return X2
+    """
+    split_list_in_half = lambda pair: [pair[:2], pair[2:]] + [[1, 1]]
     gens = _create_fake_gens(
         np.array(
             list(map(split_list_in_half, product([0, 1], repeat=4))), dtype=np.bool_
@@ -292,21 +445,34 @@ def test_ppt_case():
     """
     Test the example case from my powerpoint slides
     This is a more complicated example.
-    TODO: adjust the genotypes and phenotypes to achieve the phenotypes I want
+    Two causal SNPs on a single haplotype and three causal SNPs on another haplotype,
+    both with perfect phenotype associations plus an extra non-causal SNP
+    The two haplotypes occur on the same tree and share two SNPs: one being the root
+    and another being SNP2 (with different alleles)
+    Y = 0.5 * ( ( X1 && X2 ) || ( X1 && X2 && X3 ) )
+    This should yield two different haplotypes for each of the alleles.
+    The pseudocode looks like:
+        if X1:
+            return X2
+        else:
+            if X2:
+                return 0
+            return X3
     """
+    # a function for splitting a list into a list of pairs
+    split_list = lambda pair: [pair[i : i + 2] for i in range(0, len(pair), 2)]
     # create genotypes for 3 samples, 4 SNPs
     gens = _create_fake_gens(
         np.array(
-            [
-                [[0, 0], [1, 1], [1, 1], [1, 1]],
-                [[0, 1], [1, 0], [0, 0], [1, 0]],
-                [[1, 1], [0, 0], [0, 0], [0, 0]],
-            ],
-            dtype=np.bool_,
+            list(map(split_list_in_half, product([0, 1], repeat=4 * 2))), dtype=np.bool_
         )
     )
-    # create phenotypes for 3 samples
-    phens = _create_fake_phens(np.array([3, 6, 7], dtype=np.float64))
+    gts = gens.data
+    # create phenotypes for 3 samples, excluding the last
+    phens = _create_fake_phens(
+        0.5
+        * ((gts[:, 0] & gts[:, 1]) | (~gts[:, 0] & ~gts[:, 1] & gts[:, 2])).sum(axis=1)
+    )
 
     # run the treebuilder and extract the haplotypes
     tree = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2)).run(root=0)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -13,6 +13,7 @@ from happler.tree import (
     Tree,
     TreeBuilder,
     AssocTestSimple,
+    NodeResults,
 )
 
 
@@ -142,7 +143,7 @@ def test_haplotypes_write():
     snp3 = Variant(idx=2, id="SNP3", pos=3)
 
     # create a results object that all of the SNPs can share
-    res = np.array([(0.1, 0.1)], dtype=[("beta", np.float64), ("pval", np.float64)])[0]
+    res = NodeResults(beta=0.1, pval=0.1)
 
     # create a tree composed of these nodes
     tree = Tree(root=snp1)


### PR DESCRIPTION
The example tests in 9e93a98562c04904f549fd5659da97323ed31d55 add non-causal variants to many of the existing tests. I also made some improvements to a special test case derived from some slides I presented a while back.

I also implemented termination of tree building via a t-test in ae57afac4bef9968804003bdf76bbd76102859ac

Lastly, I wrote up full documentation for the haplotype output file format. This resolves #9 