### PR TITLE
handle edge cases revealed by example tests

### DIFF
--- a/happler/__main__.py
+++ b/happler/__main__.py
@@ -97,7 +97,7 @@ def run(
     # load data
     gt = data.Genotypes.load(genotypes, region=region, samples=samples)
     ph = data.Phenotypes.load(phenotypes, samples=samples)
-    hap_tree = tree.TreeBuilder(gt, ph)
+    hap_tree = tree.TreeBuilder(gt, ph).run()
 
 
 if __name__ == "__main__":

--- a/happler/tree/haplotypes.py
+++ b/happler/tree/haplotypes.py
@@ -10,9 +10,6 @@ from ..data import Genotypes
 from .variant import Variant
 
 
-# We declare this class to be a dataclass to automatically define __init__ and a few
-# other methods. We use frozen=True to make it immutable.
-@dataclass(frozen=True)
 class Haplotype:
     """
     A haplotype within the tree
@@ -29,6 +26,19 @@ class Haplotype:
     # TODO: consider using a named tuple?
     nodes: tuple[tuple[Variant, int]]
     data: npt.NDArray[np.bool_]
+
+    def __init__(self, num_samples: int):
+        """
+        Initialize an empty haplotype
+
+        Parameters
+        ----------
+        num_samples : int
+            The number of samples in this haplotype
+        """
+        self.nodes = tuple()
+        self.data = np.ones((num_samples, 1), dtype=np.bool_)
+
 
     @classmethod
     def from_node(

--- a/happler/tree/haplotypes.py
+++ b/happler/tree/haplotypes.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import sys
+from typing import TextIO
 from pathlib import Path
 
 import numpy as np
@@ -235,17 +237,16 @@ class Haplotypes:
         ]
         return haps
 
-    def write(self, fname: Path):
+    def write(self, file: TextIO):
         """
         Write the contents of this Haplotypes object to the file given by fname
 
         Parameters
         ----------
-        fname : Path
-            The path to the file to which this Haplotypes object should be written.
+        file : TextIO
+            A file-like object to which this Haplotypes object should be written.
         """
-        with open(fname, "w") as file:
-            for hap in self.data:
-                file.write(self.format["hap"]["str"].format(**hap))
-                for var in hap["variants"]:
-                    file.write(self.format["var"]["str"].format(**var))
+        for hap in self.data:
+            file.write(self.format["hap"]["str"].format(**hap))
+            for var in hap["variants"]:
+                file.write(self.format["var"]["str"].format(**var))

--- a/happler/tree/haplotypes.py
+++ b/happler/tree/haplotypes.py
@@ -215,6 +215,7 @@ class Haplotypes:
 
     @classmethod
     def from_tree(cls, tree: Tree) -> Haplotypes:
+        # TODO: check whether allele is correct; I think it's actually the parent's
         haps = cls()
         haplotypes = tree.haplotypes()
         haps.data = [

--- a/happler/tree/haplotypes.py
+++ b/happler/tree/haplotypes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from pathlib import Path
-from dataclasses import dataclass
 
 import numpy as np
 import numpy.typing as npt
@@ -27,18 +26,35 @@ class Haplotype:
     nodes: tuple[tuple[Variant, int]]
     data: npt.NDArray[np.bool_]
 
-    def __init__(self, num_samples: int):
+    def __init__(
+        self,
+        nodes: tuple[tuple[Variant, int]] = tuple(),
+        data: npt.NDArray[np.bool_] = None,
+        num_samples: int = None,
+    ):
         """
         Initialize an empty haplotype
 
         Parameters
         ----------
+        nodes : tuple[tuple[Variant, int]]
+            An ordered collection of pairs, where each pair is a node and its allele
+        data : npt.NDArray[np.bool_]
+            A np array (with shape n x 1, the number of samples) denoting the presence
+            of this haplotype in each sample
         num_samples : int
             The number of samples in this haplotype
         """
-        self.nodes = tuple()
-        self.data = np.ones((num_samples, 1), dtype=np.bool_)
-
+        self.nodes = nodes
+        if num_samples and data is None:
+            self.data = np.ones(num_samples, dtype=np.bool_)
+        elif num_samples is None:
+            self.data = data
+        else:
+            raise ValueError(
+                "The data and num_samples arguments are mutually exclusive. Provide"
+                " either one or the other."
+            )
 
     @classmethod
     def from_node(

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -23,10 +23,13 @@ class NodeResults:
         The best effect size among all of the SNPs tried
     pval : float
         The best p-value among all of the SNPs tried
+    stderr: float
+        The standard error of beta
     """
 
     beta: float
     pval: float
+    stderr: float
 
     def __getitem__(self, item):
         """
@@ -39,6 +42,14 @@ class NodeResults:
         ``obj.field_name``
         """
         return getattr(self, item)
+
+    @classmethod
+    def from_np(cls, np_mixed_arr_var: np.void) -> NodeResults:
+        class_attributes = cls.__dict__['__dataclass_fields__'].keys()
+        return cls(**dict(zip(
+            class_attributes,
+            np_mixed_arr_var
+        )))
 
 
 class Tree:

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -134,15 +134,21 @@ class Tree:
 
             Each dictionary contains the node and all of its attributes.
         """
+        # how many children does this node have?
+        num_children = self.graph.out_degree(root)
         # check: is the root index 0 or some other int?
         if root:
             root_node = deque([self.graph.nodes[root]])
-        else:
+        elif num_children:
             # this root is actually the absolute root, which doesn't represent a real
             # variant, so we just use an empty deque in that case
             root_node = deque([])
+        else:
+            # if the root is actually the absolute root and there aren't any children,
+            # just return an empty list
+            return []
         # first, check that this node is not a leaf
-        if self.graph.out_degree(root):
+        if num_children:
             return [
                 root_node + path
                 for child in self.graph.successors(root)

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -45,11 +45,8 @@ class NodeResults:
 
     @classmethod
     def from_np(cls, np_mixed_arr_var: np.void) -> NodeResults:
-        class_attributes = cls.__dict__['__dataclass_fields__'].keys()
-        return cls(**dict(zip(
-            class_attributes,
-            np_mixed_arr_var
-        )))
+        class_attributes = cls.__dict__["__dataclass_fields__"].keys()
+        return cls(**dict(zip(class_attributes, np_mixed_arr_var)))
 
 
 class Tree:

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -113,8 +113,11 @@ class Tree:
                 " more children."
             )
         new_node_idx = self.num_nodes
+        label = ''
+        if node is not None:
+            label = node.id
         self.graph.add_node(
-            new_node_idx, variant=node, label=node.id, allele=allele, results=results
+            new_node_idx, variant=node, label=label, allele=allele, results=results
         )
         self.variant_locs[node].add(new_node_idx)
         self.graph.add_edge(parent_idx, new_node_idx, label=allele)

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -97,7 +97,7 @@ class Tree:
         parent_idx : int
             The index of the node under which to place the new node
         allele : int
-            The allele for the edge from parent to node
+            The allele for the edge from a parent node to this node
         results : np.void, optional
             The results (beta, pval) of the association test for this haplotype once
             this variant is included

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -158,7 +158,7 @@ class Tree:
             # node.set_name(node.get('label'))
             attrs = node.get_attributes()
             # check: does this node have a valid variant attached to it?
-            if attrs["variant"] == 'None':
+            if attrs["variant"] == "None":
                 # treat the root node specially, since it isn't a real variant
                 node.obj_dict["attributes"] = {"label": "root"}
             else:

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -148,7 +148,7 @@ class TreeBuilder:
         # step 3: find the index of the best variant within the haplotype matrix
         best_p_idx = p_values.argmin()
         best = results.data[best_p_idx]
-        node_res = NodeResults(beta=best["beta"], pval=best["pval"])
+        node_res = NodeResults.from_np(best)
         # step 4: check whether we should terminate the branch
         if self.check_terminate_branch(
             parent_res, node_res, hap_matrix.shape[1], len(p_values)

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -102,7 +102,7 @@ class TreeBuilder:
             else:
                 # if parent is not defined, it means we're at the root of the tree, so
                 # we need to create a new empty haplotype
-                new_parent_hap = Haplotype(len(self.gens.samples))
+                new_parent_hap = Haplotype(num_samples=len(self.gens.samples))
             # find the best variant, add it to the tree, and then create a new subtree
             # under it
             best_variant, results = self._find_split(

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -207,7 +207,7 @@ class TreeBuilder:
             # right now, we're handling this case by choosing not to terminate
             # this means that we are guaranteed to have at least one SNP in our tree
             # but we should probably do something more intelligent in the future
-            return True
+            return False
         # correct for multiple hypothesis testing
         # For now, we use the Bonferroni correction
         return pval >= self.method.pval_thresh / num_tests

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -96,13 +96,13 @@ class TreeBuilder:
         """
         # find the variant that gives the best haplotype
         variant, results = self._find_split(parent_hap, parent_res)
-        if variant is None:
-            # there were no significant variants!
-            return
         # add the best variant to the tree
         new_node_idx = self.tree.add_node(
             variant, parent_idx, allele, results=results
         )
+        if variant is None:
+            # there were no significant variants!
+            return
         # we consider two possible alleles for the best variant
         alleles = (0, 1)
         for allele in alleles:
@@ -148,7 +148,7 @@ class TreeBuilder:
         if self.check_terminate(
             parent_res, node_res, hap_matrix.shape[0], len(p_values)
         ):
-            return None, best
+            return None, node_res
         # step 5: find the index of the best variant within the genotype matrix
         # we need to account for indices that we removed when running transform()
         # There might be a faster way of doing this but for now we're just going to
@@ -188,6 +188,11 @@ class TreeBuilder:
             True if the branch should be terminated, False otherwise
         """
         if parent_res:
+            # # before we do any calculations, check whether the effect sizes have the
+            # # same sign and return True if they do
+            # if np.sign(node_res.beta) != np.sign(parent_res.beta):
+            #     # terminate if they have different signs
+            #     return True
             # perform a two tailed, two-sample t-test using the difference of the effect sizes
             # first, we compute the standard error of the difference of the effect sizes
             std_err = np.sqrt(((node_res.stderr ** 2) + (parent_res.stderr ** 2)) / 2)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -51,6 +51,8 @@ def _create_fake_phens(data) -> Phenotypes:
     """
     phens = Phenotypes(fname=None)
     phens.samples = tuple("samp" + str(i) for i in range(data.shape[0]))
+    if len(data.shape) > 1:
+        data = np.squeeze(data)
     phens.data = data
     phens.standardize()
     return phens
@@ -80,10 +82,14 @@ def test_one_snp_perfect():
     haps = tree.haplotypes()
 
     # check: did the output turn out how we expected?
-    # one haplotype: with one SNP
-    assert len(haps) == 1
+    # two haplotypes: with the same SNP but different alleles
+    assert len(haps) == 2
     assert len(haps[0]) == 1
     assert haps[0][0]["variant"].id == "snp0"
+    assert haps[0][0]["allele"] == 0
+    assert len(haps[1]) == 1
+    assert haps[1][0]["variant"].id == "snp0"
+    assert haps[1][0]["allele"] == 1
 
 
 def test_one_snp_not_causal():

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -76,7 +76,7 @@ def test_one_snp_perfect():
     phens = _create_fake_phens(gens.data.sum(axis=2) * 0.5)
 
     # run the treebuilder and extract the haplotypes
-    tree = TreeBuilder(gens, phens).run(root=0)
+    tree = TreeBuilder(gens, phens).run()
     haps = tree.haplotypes()
 
     # check: did the output turn out how we expected?
@@ -106,7 +106,7 @@ def test_one_snp_not_causal():
 
     # run the treebuilder and extract the haplotypes
     # TODO: figure out how to handle this case
-    tree = TreeBuilder(gens, phens).run(root=0)
+    tree = TreeBuilder(gens, phens).run()
     haps = tree.haplotypes()
 
     # check: did the output turn out how we expected?
@@ -134,7 +134,7 @@ def test_two_snps_single_association():
     phens = _create_fake_phens(gens.data.sum(axis=2)[:, 0] * 0.5)
 
     # run the treebuilder and extract the haplotypes
-    tree = TreeBuilder(gens, phens).run(root=0)
+    tree = TreeBuilder(gens, phens).run()
     haps = tree.haplotypes()
 
     # check: did the output turn out how we expected?
@@ -161,7 +161,7 @@ def test_two_snps_independent_perfect():
     # TODO: we need to handle this case, somehow
     # # run the treebuilder and extract the haplotypes
     # builder = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2))
-    # builder.run(root=0)
+    # builder.run()
     # tree = builder.tree
     # haps = tree.haplotypes()
     assert False
@@ -186,7 +186,7 @@ def test_two_snps_one_branch_perfect():
     phens = _create_fake_phens(0.5 * (gts[:, 0] & gts[:, 1]).sum(axis=1))
 
     # run the treebuilder and extract the haplotypes
-    tree = TreeBuilder(gens, phens).run(root=0)
+    tree = TreeBuilder(gens, phens).run()
     haps = tree.haplotypes()
 
     # check: did the output turn out how we expected?
@@ -217,7 +217,7 @@ def test_three_snps_one_branch_one_snp_not_causal():
     phens = _create_fake_phens(0.5 * (gts[:, 0] & gts[:, 1]).sum(axis=1))
 
     # run the treebuilder and extract the haplotypes
-    tree = TreeBuilder(gens, phens).run(root=0)
+    tree = TreeBuilder(gens, phens).run()
     haps = tree.haplotypes()
 
     # check: did the output turn out how we expected?
@@ -251,7 +251,7 @@ def test_four_snps_two_independent_trees_perfect():
     # TODO: we need to handle this case, somehow
     # # run the treebuilder and extract the haplotypes
     # builder = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2))
-    # builder.run(root=0)
+    # builder.run()
     # tree = builder.tree
     # haps = tree.haplotypes()
     assert False
@@ -281,7 +281,7 @@ def test_four_snps_two_independent_trees_perfect_one_snp_not_causal():
     # TODO: we need to handle this case, somehow
     # # run the treebuilder and extract the haplotypes
     # builder = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2))
-    # builder.run(root=0)
+    # builder.run()
     # tree = builder.tree
     # haps = tree.haplotypes()
     assert False
@@ -312,7 +312,7 @@ def test_four_snps_two_independent_trees_perfect_two_snps_not_causal():
     # TODO: we need to handle this case, somehow
     # # run the treebuilder and extract the haplotypes
     # builder = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2))
-    # builder.run(root=0)
+    # builder.run()
     # tree = builder.tree
     # haps = tree.haplotypes()
     assert False
@@ -339,7 +339,7 @@ def test_three_snps_two_independent_trees_perfect():
     # TODO: we need to handle this case, somehow
     # # run the treebuilder and extract the haplotypes
     # builder = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2))
-    # builder.run(root=0)
+    # builder.run()
     # tree = builder.tree
     # haps = tree.haplotypes()
     assert False
@@ -366,7 +366,7 @@ def test_three_snps_two_independent_trees_perfect_one_snp_not_causal():
     # TODO: we need to handle this case, somehow
     # # run the treebuilder and extract the haplotypes
     # builder = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2))
-    # builder.run(root=0)
+    # builder.run()
     # tree = builder.tree
     # haps = tree.haplotypes()
     assert False
@@ -393,7 +393,7 @@ def test_two_snps_two_branches_perfect():
     phens = _create_fake_phens(0.5 * (gts[:, 0] | gts[:, 1]).sum(axis=1))
 
     # run the treebuilder and extract the haplotypes
-    tree = TreeBuilder(gens, phens).run(root=0)
+    tree = TreeBuilder(gens, phens).run()
     haps = tree.haplotypes()
 
     # check: did the output turn out how we expected?
@@ -428,7 +428,7 @@ def test_two_snps_two_branches_perfect_one_snp_not_causal():
     phens = _create_fake_phens(0.5 * (gts[:, 0] | gts[:, 1]).sum(axis=1))
 
     # run the treebuilder and extract the haplotypes
-    tree = TreeBuilder(gens, phens).run(root=0)
+    tree = TreeBuilder(gens, phens).run()
     haps = tree.haplotypes()
 
     # check: did the output turn out how we expected?
@@ -475,7 +475,7 @@ def test_ppt_case():
     )
 
     # run the treebuilder and extract the haplotypes
-    tree = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2)).run(root=0)
+    tree = TreeBuilder(gens, phens, AssocTestSimple(pval_thresh=2)).run()
     haps = tree.haplotypes()
 
     # check: did the output turn out how we expected?

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -54,7 +54,12 @@ def _create_fake_phens(data) -> Phenotypes:
     if len(data.shape) > 1:
         data = np.squeeze(data)
     phens.data = data
-    phens.standardize()
+    # check: are all of the phenotype values the same?
+    if np.all(phens.data == phens.data[0]):
+        # if they're all the same, don't standardize b/c then we'll end up with NAs
+        phens.data = np.zeros(phens.data.shape)
+    else:
+        phens.standardize()
     return phens
 
 
@@ -108,10 +113,9 @@ def test_one_snp_not_causal():
             dtype=np.bool_,
         )
     )
-    phens = _create_fake_phens(np.ones(gens.data.sum(axis=2).shape) * 0.5)
+    phens = _create_fake_phens(np.ones(gens.data.sum(axis=2).shape))
 
     # run the treebuilder and extract the haplotypes
-    # TODO: figure out how to handle this case
     tree = TreeBuilder(gens, phens).run()
     haps = tree.haplotypes()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,6 +1,7 @@
-import numpy as np
-
 from itertools import product
+
+import pytest
+import numpy as np
 
 from happler.data import Genotypes, Phenotypes
 from happler.tree import TreeBuilder, AssocTestSimple
@@ -63,6 +64,16 @@ def _create_fake_phens(data) -> Phenotypes:
     return phens
 
 
+def _view_tree_haps(tree) -> list:
+    """
+    Return the haplotype contents of a tree in an easily viewable form
+    """
+    return [
+        [(node["variant"].id, node["allele"]) for node in haplotype]
+        for haplotype in tree.haplotypes()
+    ]
+
+
 def test_one_snp_perfect():
     """
     The most simple case. One causal SNP with a perfect phenotype association:
@@ -120,7 +131,7 @@ def test_one_snp_not_causal():
     haps = tree.haplotypes()
 
     # check: did the output turn out how we expected?
-    # one haplotype: with one SNP
+    # no haplotypes!
     assert len(haps) == 0
 
 
@@ -145,19 +156,18 @@ def test_two_snps_single_association():
 
     # run the treebuilder and extract the haplotypes
     tree = TreeBuilder(gens, phens).run()
-    haps = tree.haplotypes()
+    haps = _view_tree_haps(tree)
 
     # check: did the output turn out how we expected?
     # two haplotypes: one for each allele of the first SNP
     assert len(haps) == 2
     assert len(haps[0]) == 1
     assert len(haps[1]) == 1
-    assert haps[0][0]["variant"].id == "snp0"
-    assert haps[1][0]["variant"].id == "snp0"
-    assert haps[0][0]["allele"] == 0
-    assert haps[1][0]["allele"] == 1
+    assert haps[0][0] == ("snp0", 0)
+    assert haps[1][0] == ("snp0", 1)
 
 
+@pytest.mark.xfail(reason="not implemented yet")
 def test_two_snps_independent_perfect():
     """
     Two independent causal SNPs with perfect phenotype associations
@@ -185,10 +195,11 @@ def test_two_snps_one_branch_perfect():
     """
     Two causal SNPs on a single haplotype with perfect phenotype associations
     Y = 0.5 * ( X1 && X2 )
-    This should yield a single haplotype with both SNPs having the same allele.
+    This should yield two haplotype with both SNPs having the same allele.
     The psuedocode looks like:
         if X1:
             return X2
+        return 0
     """
     split_list_in_half = lambda pair: [pair[:2], pair[2:]]
     gens = _create_fake_gens(
@@ -201,7 +212,8 @@ def test_two_snps_one_branch_perfect():
 
     # run the treebuilder and extract the haplotypes
     tree = TreeBuilder(gens, phens).run()
-    haps = tree.haplotypes()
+    haps = _view_tree_haps(tree)
+    breakpoint()
 
     # check: did the output turn out how we expected?
     # one haplotype with both SNPs
@@ -243,6 +255,7 @@ def test_three_snps_one_branch_one_snp_not_causal():
     assert haps[0][2]["allele"] == 1
 
 
+@pytest.mark.xfail(reason="not implemented yet")
 def test_four_snps_two_independent_trees_perfect():
     """
     Two independent causal SNPs each sharing a haplotype with another, different SNP
@@ -271,6 +284,7 @@ def test_four_snps_two_independent_trees_perfect():
     assert False
 
 
+@pytest.mark.xfail(reason="not implemented yet")
 def test_four_snps_two_independent_trees_perfect_one_snp_not_causal():
     """
     Two independent causal SNPs each sharing a haplotype with another, different SNP
@@ -301,6 +315,7 @@ def test_four_snps_two_independent_trees_perfect_one_snp_not_causal():
     assert False
 
 
+@pytest.mark.xfail(reason="not implemented yet")
 def test_four_snps_two_independent_trees_perfect_two_snps_not_causal():
     """
     Two independent causal SNPs each sharing a haplotype with another, different SNP
@@ -332,6 +347,7 @@ def test_four_snps_two_independent_trees_perfect_two_snps_not_causal():
     assert False
 
 
+@pytest.mark.xfail(reason="not implemented yet")
 def test_three_snps_two_independent_trees_perfect():
     """
     Two independent causal SNPs each sharing a haplotype with the third SNP via
@@ -359,6 +375,7 @@ def test_three_snps_two_independent_trees_perfect():
     assert False
 
 
+@pytest.mark.xfail(reason="not implemented yet")
 def test_three_snps_two_independent_trees_perfect_one_snp_not_causal():
     """
     Two independent causal SNPs each sharing a haplotype with the third SNP via

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -148,10 +148,14 @@ def test_two_snps_single_association():
     haps = tree.haplotypes()
 
     # check: did the output turn out how we expected?
-    # one haplotype: with one SNP
-    assert len(haps) == 1
+    # two haplotypes: one for each allele of the first SNP
+    assert len(haps) == 2
     assert len(haps[0]) == 1
+    assert len(haps[1]) == 1
     assert haps[0][0]["variant"].id == "snp0"
+    assert haps[1][0]["variant"].id == "snp0"
+    assert haps[0][0]["allele"] == 0
+    assert haps[1][0]["allele"] == 1
 
 
 def test_two_snps_independent_perfect():

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -65,14 +65,13 @@ def _create_fake_phens(data) -> Phenotypes:
 
 
 def _view_tree_helper(haplotype):
-    skip_first = True
+    prev_node = ''
     for node in haplotype:
-        prev_node = node["variant"].id
-        if skip_first:
-            skip_first = False
-            continue
-        yield (prev_node, node["allele"])
-    yield (prev_node, None)
+        if prev_node:
+            yield (prev_node, node["allele"])
+        prev_node = node["label"]
+    if prev_node:
+        yield (prev_node, None)
 
 
 def _view_tree_haps(tree) -> list:

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -112,7 +112,7 @@ def test_tree_builder():
     gens = Genotypes.load(DATADIR.joinpath("simple.vcf"))
     phens = Phenotypes.load(DATADIR.joinpath("simple.tsv"))
     tree_builder = TreeBuilder(gens, phens)
-    tree_builder.run()
+    tree = tree_builder.run()
     # TODO: assert that the tree looks correct
     assert False
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -73,7 +73,10 @@ def test_tree_dot():
     tree.add_node(snp3, node_idx, 1)
     assert (
         tree.dot()
-        == 'strict digraph  {\n0 [label=root];\n1 [label=SNP0];\n2 [label=SNP1];\n3 [label=SNP2];\n4 [label=SNP3];\n5 [label=SNP3];\n0 -> 1  [label=0];\n1 -> 2  [label=0];\n2 -> 3  [label=1];\n3 -> 4  [label=0];\n3 -> 5  [label=1];\n}\n'
+        == "strict digraph  {\n0 [label=root];\n1 [label=SNP0];\n2 [label=SNP1];\n3"
+        " [label=SNP2];\n4 [label=SNP3];\n5 [label=SNP3];\n0 -> 1  [label=0];\n1 ->"
+        " 2  [label=0];\n2 -> 3  [label=1];\n3 -> 4  [label=0];\n3 -> 5 "
+        " [label=1];\n}\n"
     )
 
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -46,28 +46,34 @@ def test_node():
 
 
 def test_tree():
-    node = Variant(idx=0, id="SNP0", pos=1)
-    tree = Tree(root=node)
+    tree = Tree()
 
-    assert tree.num_nodes == 1
+    snp0 = Variant(idx=0, id="SNP0", pos=1)
+    tree.add_node(snp0, parent_idx=0, allele=0)
+    assert tree.num_nodes, tree.num_variants == (2, 1)
+    tree.add_node(snp0, parent_idx=0, allele=1)
+    assert tree.num_nodes, tree.num_variants == (3, 1)
 
-    tree.add_node(Variant(idx=1, id="SNP1", pos=2), 0, 0)
-
-    assert tree.num_nodes == 2
+    snp1 = Variant(idx=1, id="SNP1", pos=2)
+    with pytest.raises(ValueError):
+        tree.add_node(snp1, parent_idx=0, allele=0)
+    assert tree.num_nodes, tree.num_variants == (3, 1)
+    tree.add_node(snp1, parent_idx=1, allele=0)
+    assert tree.num_nodes, tree.num_variants == (4, 2)
 
 
 def test_tree_dot():
     node = Variant(idx=0, id="SNP0", pos=1)
-    tree = Tree(root=node)
-    node_idx = tree.add_node(Variant(idx=1, id="SNP1", pos=2), 0, 0)
-    tree.add_node(Variant(idx=2, id="SNP2", pos=3), 0, 1)
-    tree.add_node(Variant(idx=3, id="SNP3", pos=4), node_idx, 0)
-    tree.add_node(Variant(idx=4, id="SNP4", pos=5), node_idx, 1)
+    tree = Tree()
+    node_idx = tree.add_node(node, 0, 0)
+    node_idx = tree.add_node(Variant(idx=1, id="SNP1", pos=2), node_idx, 0)
+    node_idx = tree.add_node(Variant(idx=2, id="SNP2", pos=3), node_idx, 1)
+    snp3 = Variant(idx=3, id="SNP3", pos=4)
+    tree.add_node(snp3, node_idx, 0)
+    tree.add_node(snp3, node_idx, 1)
     assert (
         tree.dot()
-        == "strict digraph  {\n0 [label=SNP0];\n1 [label=SNP1];\n2 [label=SNP2];\n3"
-        " [label=SNP3];\n4 [label=SNP4];\n0 -> 1  [label=0];\n0 -> 2  [label=1];\n1"
-        " -> 3  [label=0];\n1 -> 4  [label=1];\n}\n"
+        == 'strict digraph  {\n0 [label=root];\n1 [label=SNP0];\n2 [label=SNP1];\n3 [label=SNP2];\n4 [label=SNP3];\n5 [label=SNP3];\n0 -> 1  [label=0];\n1 -> 2  [label=0];\n2 -> 3  [label=1];\n3 -> 4  [label=0];\n3 -> 5  [label=1];\n}\n'
     )
 
 
@@ -77,15 +83,16 @@ def test_get_haplotypes_from_tree():
     snp2 = Variant(idx=1, id="SNP2", pos=2)
     snp3 = Variant(idx=2, id="SNP3", pos=3)
 
-    # create a tree composed of just one node
-    tree = Tree(root=snp1)
+    # create a tree composed of just one variant
+    tree = Tree()
+    snp1_idx = tree.add_node(snp1, parent_idx=0, allele=0)
     haps = tree.haplotypes()
     assert len(haps) == 1
     assert haps[0][0]["variant"] == snp1
 
     # add two child nodes
-    snp2_idx = tree.add_node(snp2, parent_idx=0, allele=0)
-    tree.add_node(snp2, parent_idx=0, allele=1)
+    snp2_idx = tree.add_node(snp2, parent_idx=snp1_idx, allele=0)
+    tree.add_node(snp2, parent_idx=snp1_idx, allele=1)
     haps = tree.haplotypes()
     assert len(haps) == 2
     assert tuple([len(hap) for hap in haps]) == (2, 2)
@@ -105,9 +112,9 @@ def test_tree_builder():
     gens = Genotypes.load(DATADIR.joinpath("simple.vcf"))
     phens = Phenotypes.load(DATADIR.joinpath("simple.tsv"))
     tree_builder = TreeBuilder(gens, phens)
-    root_node = 0
-    tree_builder.run(root_node)
+    tree_builder.run()
     # TODO: assert that the tree looks correct
+    assert False
 
 
 def test_haplotype():
@@ -146,10 +153,12 @@ def test_haplotypes_write():
     res = NodeResults(beta=0.1, pval=0.1)
 
     # create a tree composed of these nodes
-    tree = Tree(root=snp1)
-    snp2_idx = tree.add_node(snp2, parent_idx=0, allele=0, results=res)
-    tree.add_node(snp2, parent_idx=0, allele=1, results=res)
+    tree = Tree()
+    snp1_idx = tree.add_node(snp1, parent_idx=0, allele=0, results=res)
+    snp2_idx = tree.add_node(snp2, parent_idx=snp1_idx, allele=1, results=res)
     tree.add_node(snp3, parent_idx=snp2_idx, allele=1, results=res)
+    snp1_idx = tree.add_node(snp1, parent_idx=0, allele=1, results=res)
+    snp2_idx = tree.add_node(snp2, parent_idx=snp1_idx, allele=0, results=res)
 
     # write the tree to a file
     Haplotypes.from_tree(tree).write("test_write.haps")
@@ -159,12 +168,12 @@ def test_haplotypes_write():
         lines = [line.rstrip() for line in file.readlines()]
         assert lines == [
             "H\t0\t0\t0.00\t0.00\tnan",
-            "V\tSNP1\tnan\tnan",
-            "V\tSNP2\t0\t0.10",
+            "V\tSNP1\t0\t0.10",
+            "V\tSNP2\t1\t0.10",
             "V\tSNP3\t1\t0.10",
             "H\t1\t0\t0.00\t0.00\tnan",
-            "V\tSNP1\tnan\tnan",
-            "V\tSNP2\t1\t0.10",
+            "V\tSNP1\t1\t0.10",
+            "V\tSNP2\t0\t0.10",
         ]
 
     # remove the file

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -111,11 +111,12 @@ def test_get_haplotypes_from_tree():
     assert [haps[1][i]["variant"] for i in range(2)] == [snp1, snp2]
 
 
+@pytest.mark.skip(reason="test not completely written yet")
 def test_tree_builder():
     gens = Genotypes.load(DATADIR.joinpath("simple.vcf"))
     phens = Phenotypes.load(DATADIR.joinpath("simple.tsv"))
     tree_builder = TreeBuilder(gens, phens)
-    tree = tree_builder.run()
+    # tree = tree_builder.run()
     # TODO: assert that the tree looks correct
     assert False
 
@@ -153,7 +154,7 @@ def test_haplotypes_write():
     snp3 = Variant(idx=2, id="SNP3", pos=3)
 
     # create a results object that all of the SNPs can share
-    res = NodeResults(beta=0.1, pval=0.1)
+    res = NodeResults(beta=0.1, pval=0.1, stderr=0.1)
 
     # create a tree composed of these nodes
     tree = Tree()
@@ -164,7 +165,8 @@ def test_haplotypes_write():
     snp2_idx = tree.add_node(snp2, parent_idx=snp1_idx, allele=0, results=res)
 
     # write the tree to a file
-    Haplotypes.from_tree(tree).write("test_write.haps")
+    with open("test_write.haps", "w") as file:
+        Haplotypes.from_tree(tree).write(file)
 
     # verify that the results appear as intended
     with open("test_write.haps", "r") as file:


### PR DESCRIPTION
1. Alter the tree builder code so that the initial variant (ie the root variant) is chosen via an association test rather than whatever variant is specified via a parameter. This helped me pass a few test cases involving a single causal SNP and a few test cases with non-causal SNPs.
2. Alter the tree builder code so that the leaves of the tree are empty (ie they have no associated variant). This is so that I can perform association tests for the alleles of the SNPs that were at the leaves before. Otherwise, the final variants of each haplotype wouldn't have an allele associated with them.
3. Continue working on resolving test cases. All of them pass up to test_two_snps_one_branch_perfect. That's the one I'm working on currently.