### PR TITLE
pass two_snps_perfect tests

### DIFF
--- a/docs/executing/outputs.rst
+++ b/docs/executing/outputs.rst
@@ -83,10 +83,18 @@ Variant lines must follow the haplotype to which they belong. They contain the f
      - string
      - The unique ID for this variant, as defined in the genotypes file
    * - 2
+     - Haplotype ID
+     - int
+     - Identifies a haplotype within a tree; unique across other haplotypes in the tree
+   * - 3
+     - Tree ID
+     - int
+     - A unique identifier for the tree that this haplotype belongs to
+   * - 4
      - Allele
      - bool
      - The allele of this variant within the haplotype
-   * - 3
+   * - 5
      - Score
      - float
      - The importance of including this variant within the haplotype

--- a/happler/tree/assoc_test.py
+++ b/happler/tree/assoc_test.py
@@ -19,6 +19,8 @@ class AssocResults:
     ----------
     data : npt.NDArray[np.float64]
         A numpy mixed array with fields: beta, pval, stderr
+
+        It has shape num_variants x num_fields
     """
 
     data: npt.NDArray[np.float64, np.float64, np.float64]

--- a/happler/tree/haplotypes.py
+++ b/happler/tree/haplotypes.py
@@ -20,8 +20,8 @@ class Haplotype:
     nodes : tuple[tuple[Variant, int]]
         An ordered collection of pairs, where each pair is a node and its allele
     data : npt.NDArray[np.bool_]
-        A np array (with shape n x 1, the number of samples) denoting the presence
-        of this haplotype in each sample
+        A np array (with shape n x 2, num_samples x num_chromosomes) denoting the
+        presence of this haplotype in each chromosome of each sample
     """
 
     # TODO: consider using a named tuple?
@@ -42,14 +42,14 @@ class Haplotype:
         nodes : tuple[tuple[Variant, int]]
             An ordered collection of pairs, where each pair is a node and its allele
         data : npt.NDArray[np.bool_]
-            A np array (with shape n x 1, the number of samples) denoting the presence
-            of this haplotype in each sample
+            A np array (with length n x 2, num_samples x num_chromosomes) denoting the
+            presence of this haplotype in each chromosome of each sample
         num_samples : int
             The number of samples in this haplotype
         """
         self.nodes = nodes
         if num_samples and data is None:
-            self.data = np.ones(num_samples, dtype=np.bool_)
+            self.data = np.ones((num_samples, 2), dtype=np.bool_)
         elif num_samples is None:
             self.data = data
         else:
@@ -57,6 +57,9 @@ class Haplotype:
                 "The data and num_samples arguments are mutually exclusive. Provide"
                 " either one or the other."
             )
+
+    def __repr__(self):
+        return str(self.nodes)
 
     @classmethod
     def from_node(
@@ -72,8 +75,8 @@ class Haplotype:
         allele : int
             The allele associated with node
         variant_genotypes : npt.NDArray[np.bool_]
-            A np array (with shape n x 1, the number of samples) denoting the presence of
-            this genotype in each sample
+            A np array (with length n x 2, num_samples x num_chromosomes) denoting the
+            presence of this haplotype in each chromosome of each sample
 
         Returns
         -------
@@ -95,8 +98,8 @@ class Haplotype:
         allele : int
             The allele associated with this node
         variant_genotypes : npt.NDArray[np.bool_]
-            A np array (with length n x 1, the number of samples) denoting the presence of
-            this genotype in each sample
+            A np array (with length n x 2, num_samples x num_chromosomes) denoting the
+            presence of this haplotype in each chromosome of each sample
 
         Returns
         -------
@@ -137,12 +140,14 @@ class Haplotype:
         npt.NDArray[np.bool_]
             A 3D haplotype matrix similar to the genotype matrix but with haplotypes
             instead of variants in the columns. It will have the same shape except that
-            the number of columns (second dimension) will have decreased by one.
+            the number of columns (second dimension) will have decreased by the number
+            of variants in this haplotype.
         """
         # first, remove any variants that are already in this haplotype using np.delete
+        # TODO: consider moving this outside of this function
         gens = np.delete(genotypes.data, self.node_indices, axis=1)
         # add extra axes to match shape of gens
-        hap_data = self.data[:, np.newaxis, np.newaxis]
+        hap_data = self.data[:, np.newaxis]
         # use np.logical_and to superimpose the current haplotype onto the GT matrix
         return np.logical_and(gens, hap_data)
 

--- a/happler/tree/haplotypes.py
+++ b/happler/tree/haplotypes.py
@@ -123,7 +123,7 @@ class Haplotype:
         """
         return tuple(node[0].idx for node in self.nodes)
 
-    def transform(self, genotypes: Genotypes) -> npt.NDArray[np.bool_]:
+    def transform(self, genotypes: Genotypes, allele: int) -> npt.NDArray[np.bool_]:
         """
         Transform a genotypes matrix via the current haplotype:
 
@@ -134,6 +134,8 @@ class Haplotype:
         ----------
         genotypes : Genotypes
             The genotypes which to transform using the current haplotype
+        allele : int
+            The allele (either 0 or 1) of the SNPs we're adding
 
         Returns
         -------
@@ -149,7 +151,7 @@ class Haplotype:
         # add extra axes to match shape of gens
         hap_data = self.data[:, np.newaxis]
         # use np.logical_and to superimpose the current haplotype onto the GT matrix
-        return np.logical_and(gens, hap_data)
+        return np.logical_and(gens == allele, hap_data)
 
 
 class Haplotypes:

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -33,7 +33,7 @@ class NodeResults:
 
     def __getitem__(self, item):
         """
-        Define a getter so that we can access elemeents like this:
+        Define a getter so that we can access elements like this:
 
         ``obj['field_name']``
 
@@ -42,6 +42,9 @@ class NodeResults:
         ``obj.field_name``
         """
         return getattr(self, item)
+
+    def __repr__(self):
+        return "{"+", ".join("{}={:.2e}".format(*i) for i in self.__dict__.items())+"}"
 
     @classmethod
     def from_np(cls, np_mixed_arr_var: np.void) -> NodeResults:

--- a/happler/tree/tree.py
+++ b/happler/tree/tree.py
@@ -69,6 +69,9 @@ class Tree:
         self.variant_locs = defaultdict(set)
         self._add_root_node()
 
+    def __repr__(self):
+        return self.dot()
+
     @property
     def num_nodes(self):
         return self.graph.number_of_nodes()
@@ -113,7 +116,7 @@ class Tree:
                 " more children."
             )
         new_node_idx = self.num_nodes
-        label = ''
+        label = ""
         if node is not None:
             label = node.id
         self.graph.add_node(
@@ -171,11 +174,11 @@ class Tree:
         """
         dot = nx.drawing.nx_pydot.to_pydot(self.graph)
         # iterate through all of the nodes, treating the root specially
-        for node in dot.get_nodes():
+        for idx, node in enumerate(dot.get_nodes()):
             # node.set_name(node.get('label'))
             attrs = node.get_attributes()
             # check: does this node have a valid variant attached to it?
-            if attrs["variant"] == "None":
+            if attrs["variant"] == "None" and idx == 0:
                 # treat the root node specially, since it isn't a real variant
                 node.obj_dict["attributes"] = {"label": "root"}
             else:

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -216,7 +216,7 @@ class TreeBuilder:
             # improved and return True if they haven't
             if (
                 np.isnan(node_res.beta)
-                or (np.abs(node_res.beta) - np.abs(parent_res.beta)) >= 0
+                or (np.abs(node_res.beta) - np.abs(parent_res.beta)) <= 0
             ):
                 # terminate if the effect sizes have gone in the opposite direction
                 self.log.debug("Terminated b/c effect size went in wrong direction")

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -49,12 +49,6 @@ class TreeBuilder:
     def run(self):
         """
         Run the tree builder and create a tree rooted at the provided variant
-
-        Parameters
-        ----------
-        root : int, optional
-            The index of the variant to use at the root of tree. This should be an
-            index into :py:attr:`~.TreeBuilder.gens.variants`
         """
         if self.tree is not None:
             raise AssertionError(

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -195,25 +195,22 @@ class TreeBuilder:
             True if the branch should be terminated, False otherwise
         """
         if parent_res:
-            # # before we do any calculations, check whether the effect sizes have the
-            # # same sign and return True if they do
-            # if np.sign(node_res.beta) != np.sign(parent_res.beta):
-            #     # terminate if they have different signs
-            #     return True
+            # before we do any calculations, check whether the effect sizes have
+            # improved and return True if they haven't
+            if (np.abs(node_res.beta) - np.abs(parent_res.beta)) > 0:
+                # terminate if they have different signs
+                return True
             # perform a two tailed, two-sample t-test using the difference of the effect sizes
             # first, we compute the standard error of the difference of the effect sizes
             std_err = np.sqrt(((node_res.stderr ** 2) + (parent_res.stderr ** 2)) / 2)
             # then, we compute the test statistic
             # use np.abs to account for the directions that the effect size may take
-            t_stat = np.abs(np.abs(node_res.beta) - np.abs(parent_res.beta)) / std_err
+            t_stat = np.abs(node_res.beta - parent_res.beta) / std_err
             # use a one-tailed test here b/c either the effect size becomes more
             # negative or it becomes more positive
             pval = t_dist.cdf(-t_stat, df=2 * (num_samps - 2))
         else:
-            # this will happen when the parent node is the root node
-            # right now, we're handling this case by choosing not to terminate
-            # this means that we are guaranteed to have at least one SNP in our tree
-            # but we should probably do something more intelligent in the future
+            # parent_res = None when the parent node is the root node
             pval = node_res.pval
         assert not np.isnan(pval)
         # correct for multiple hypothesis testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,11 @@ happler = 'happler.__main__:main'
 line-length = 88
 experimental-string-processing = true
 
+[tool.pytest.ini_options]
+log_cli_level = "DEBUG"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -196,7 +196,7 @@ def test_two_snps_one_branch_perfect():
     """
     Two causal SNPs on a single haplotype with perfect phenotype associations
     Y = 0.5 * ( X1 && X2 )
-    This should yield two haplotype with both SNPs having the same allele.
+    This should yield two haplotypes with both SNPs having the same allele.
     The psuedocode looks like:
         if X1:
             return X2
@@ -229,7 +229,7 @@ def test_two_snps_one_branch_perfect_opposite_allele():
     """
     Two causal SNPs on a single haplotype with perfect phenotype associations
     Y = 0.5 * ( X1 && X2 )
-    This should yield two haplotype with both SNPs having the same allele.
+    This should yield two haplotypes with the SNPs having different alleles.
     The psuedocode looks like:
         if X1:
             return X2

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -64,22 +64,12 @@ def _create_fake_phens(data) -> Phenotypes:
     return phens
 
 
-def _view_tree_helper(haplotype):
-    prev_node = ''
-    for node in haplotype:
-        if prev_node:
-            yield (prev_node, node["allele"])
-        prev_node = node["label"]
-    if prev_node:
-        yield (prev_node, None)
-
-
 def _view_tree_haps(tree) -> list:
     """
     Return the haplotype contents of a tree in an easily viewable form
     """
     return [
-        list(_view_tree_helper(haplotype))
+        [(node["label"], node["allele"]) for node in haplotype]
         for haplotype in tree.haplotypes()
     ]
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -155,9 +155,9 @@ def test_haplotype_transform():
     variant = Variant.from_np(gens.variants[variant_idx], variant_idx)
     hap = Haplotype.from_node(variant, allele, variant_gts)
     gens_without_variant = (
-        gens.data[:, (variant_idx + 1) :, :] & variant_gts[:, np.newaxis]
+        (gens.data[:, (variant_idx + 1) :, :] == allele) & variant_gts[:, np.newaxis]
     )
-    np.testing.assert_allclose(hap.transform(gens), gens_without_variant)
+    np.testing.assert_allclose(hap.transform(gens, allele), gens_without_variant)
 
 
 def test_haplotypes_write():
@@ -185,13 +185,14 @@ def test_haplotypes_write():
     with open("test_write.haps", "r") as file:
         lines = [line.rstrip() for line in file.readlines()]
         assert lines == [
+            "M\t0.0.1",
             "H\t0\t0\t0.00\t0.00\tnan",
-            "V\tSNP1\t0\t0.10",
-            "V\tSNP2\t1\t0.10",
-            "V\tSNP3\t1\t0.10",
+            "V\tSNP1\t0\t0\t0\t0.10",
+            "V\tSNP2\t0\t0\t1\t0.10",
+            "V\tSNP3\t0\t0\t1\t0.10",
             "H\t1\t0\t0.00\t0.00\tnan",
-            "V\tSNP1\t1\t0.10",
-            "V\tSNP2\t0\t0.10",
+            "V\tSNP1\t1\t0\t1\t0.10",
+            "V\tSNP2\t1\t0\t0\t0.10",
         ]
 
     # remove the file

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -123,27 +123,40 @@ def test_tree_builder():
 
 def test_haplotype():
     node = Variant(idx=0, id="SNP0", pos=1)
-    gts = np.array([0, 1, 1], dtype=np.bool_)
-    hap = Haplotype(((node, 0),), gts)
+    gts = np.array(
+        [
+            [[0, 0], [1, 1], [1, 0]],
+            [[0, 1], [1, 0], [0, 0]],
+            [[1, 0], [0, 0], [1, 1]],
+            [[1, 1], [0, 1], [0, 0]],
+        ],
+        dtype=np.bool_,
+    )
+    node_allele = 0
+    hap_data = gts[:, node.idx, :] == node_allele
+    hap = Haplotype(((node, node_allele),), hap_data)
     assert hap.nodes == Haplotype.from_node(node, 0, hap.data).nodes
 
     new_node = Variant(idx=1, id="SNP1", pos=1)
-    new_gts = np.array([1, 0, 1], dtype=np.bool_)
-    hap = hap.append(new_node, 0, new_gts)
-    nodes = ((node, 0), (new_node, 0))
+    new_node_allele = 1
+    new_hap_data = gts[:, new_node.idx, :] == new_node_allele
+    hap = hap.append(new_node, new_node_allele, new_hap_data)
+    nodes = ((node, node_allele), (new_node, new_node_allele))
     assert hap.nodes == Haplotype(nodes, hap.data).nodes
-    np.testing.assert_allclose(hap.data, np.array([0, 0, 1], np.bool_))
+    np.testing.assert_allclose(hap.data, hap_data & new_hap_data)
 
 
 def test_haplotype_transform():
     gens = Genotypes.load(DATADIR.joinpath("simple.vcf"))
     variant_idx = 0
-    allele_idx = 0
-    gens.data[:, variant_idx, allele_idx] = 1
-    variant_gts = gens.data[:, variant_idx, allele_idx]
+    allele = 0
+    gens.data[:, variant_idx, allele] = 1
+    variant_gts = gens.data[:, variant_idx, :] == allele
     variant = Variant.from_np(gens.variants[variant_idx], variant_idx)
-    hap = Haplotype.from_node(variant, allele_idx, variant_gts)
-    gens_without_variant = gens.data[:, (variant_idx + 1) :, :]
+    hap = Haplotype.from_node(variant, allele, variant_gts)
+    gens_without_variant = (
+        gens.data[:, (variant_idx + 1) :, :] & variant_gts[:, np.newaxis]
+    )
     np.testing.assert_allclose(hap.transform(gens), gens_without_variant)
 
 


### PR DESCRIPTION
closes #22

1. Added debug logger to TreeBuilder class (see 5b186b557aaea4b578000ad5620ee4bebd76f9b0)
2. Refactored `TreeBuilder._find_split()` so that **test_two_snps_one_branch_perfect** example test finally passes! (see ef0a044aa8fcbef27ab83f5fc548cb9f99cd281c for the refactor and 8f05f82e166f099ed1775d5e613615ce146d81bc for the frustratingly easy fix)
   In the process, I made lots of changes to the Haplotype class to enable allele-based data and genotype transformations (see ae04b01cd501c07db1e5ae4ba8af2f971f18c5c3 and 495b3cdb007462e0f80af98182b893b93d745fe2)
3. Add haplotype ID field and metadata to haplotype output file (see 872c71dd589fd12e5613c7b8188ebfb4a81854b8)